### PR TITLE
hevc: properly handle no_rasl_output_flag when removing pictures from DPB

### DIFF
--- a/libavcodec/avcodec.h
+++ b/libavcodec/avcodec.h
@@ -531,6 +531,10 @@ enum AVCodecID {
     AV_CODEC_ID_PJS        = MKBETAG('P','h','J','S'),
     AV_CODEC_ID_ASS        = MKBETAG('A','S','S',' '),  ///< ASS as defined in Matroska
 
+    /* data codecs */
+    AV_CODEC_ID_VBI_DATA= 0x17500,
+    AV_CODEC_ID_VBI_TELETEXT,
+
     /* other specific kind of codecs (generally used for attachments) */
     AV_CODEC_ID_FIRST_UNKNOWN = 0x18000,           ///< A dummy ID pointing at the start of various fake codecs.
     AV_CODEC_ID_TTF = 0x18000,

--- a/libavcodec/dvdsubdec.c
+++ b/libavcodec/dvdsubdec.c
@@ -64,6 +64,24 @@ static void yuv_a_to_rgba(const uint8_t *ycbcr, const uint8_t *alpha, uint32_t *
     }
 }
 
+static void ayvu_to_argb(const uint8_t *ayvu, uint32_t *argb, int num_values)
+{
+    uint8_t *cm = ff_crop_tab + MAX_NEG_CROP;
+    uint8_t r, g, b;
+    int i, y, cb, cr, a;
+    int r_add, g_add, b_add;
+
+    for (i = num_values; i > 0; i--) {
+        a = *ayvu++;
+        y = *ayvu++;
+        cr = *ayvu++;
+        cb = *ayvu++;
+        YUV_TO_RGB1_CCIR(cb, cr);
+        YUV_TO_RGB2_CCIR(r, g, b, y);
+        *argb++ = (a << 24) | (r << 16) | (g << 8) | b;
+    }
+}
+
 static int decode_run_2bit(GetBitContext *gb, int *color)
 {
     unsigned int v, t;
@@ -708,6 +726,12 @@ static av_cold int dvdsub_init(AVCodecContext *avctx)
         parse_ifo_palette(ctx, ctx->ifo_str);
     if (ctx->palette_str)
         parse_palette(ctx, ctx->palette_str);
+
+    if (!ctx->has_palette && avctx->extradata_size == 64) {
+        ayvu_to_argb((uint8_t*)avctx->extradata, ctx->palette, 16);
+        ctx->has_palette = 1;
+    }
+
     if (ctx->has_palette) {
         int i;
         av_log(avctx, AV_LOG_DEBUG, "palette:");

--- a/libavcodec/dxva2_h264.c
+++ b/libavcodec/dxva2_h264.c
@@ -497,6 +497,14 @@ static int dxva2_h264_end_frame(AVCodecContext *avctx)
 
     if (ctx_pic->slice_count <= 0 || ctx_pic->bitstream_size <= 0)
         return -1;
+
+    // Wait for an I-frame before start decoding. Workaround for ATI UVD and UVD+ GPUs
+    if (!h->got_first_iframe) {
+        if (!(ctx_pic->pp.wBitFields & (1 << 15)))
+            return -1;
+        h->got_first_iframe = 1;
+    }
+
     ret = ff_dxva2_common_end_frame(avctx, h->cur_pic_ptr->f,
                                     &ctx_pic->pp, sizeof(ctx_pic->pp),
                                     &ctx_pic->qm, sizeof(ctx_pic->qm),

--- a/libavcodec/h264.c
+++ b/libavcodec/h264.c
@@ -1107,6 +1107,7 @@ void ff_h264_flush_change(H264Context *h)
     h->mmco_reset = 1;
     for (i = 0; i < h->nb_slice_ctx; i++)
         h->slice_ctx[i].list_count = 0;
+    h->got_first_iframe = 0;
 }
 
 /* forget old pics after a seek */

--- a/libavcodec/h264.h
+++ b/libavcodec/h264.h
@@ -813,6 +813,8 @@ typedef struct H264Context {
      * slices) anymore */
     int setup_finished;
 
+    int got_first_iframe;
+
     // Timestamp stuff
     int sei_buffering_period_present;   ///< Buffering period SEI flag
     int initial_cpb_removal_delay[32];  ///< Initial timestamps for CPBs

--- a/libavcodec/h264_slice.c
+++ b/libavcodec/h264_slice.c
@@ -1043,6 +1043,7 @@ static int h264_slice_header_init(H264Context *h)
 
     h->first_field           = 0;
     h->prev_interlaced_frame = 1;
+    h->got_first_iframe = 0;
 
     init_scan_tables(h);
     ret = ff_h264_alloc_tables(h);

--- a/libavcodec/hevc.c
+++ b/libavcodec/hevc.c
@@ -809,6 +809,8 @@ static int hls_slice_header(HEVCContext *s)
     s->HEVClc->tu.cu_qp_offset_cb = 0;
     s->HEVClc->tu.cu_qp_offset_cr = 0;
 
+    s->no_rasl_output_flag = IS_IDR(s) || IS_BLA(s) || (s->nal_unit_type == NAL_CRA_NUT && s->last_eos);
+
     return 0;
 }
 
@@ -3135,6 +3137,7 @@ static int hevc_update_thread_context(AVCodecContext *dst,
     s->pocTid0    = s0->pocTid0;
     s->max_ra     = s0->max_ra;
     s->eos        = s0->eos;
+    s->no_rasl_output_flag = s0->no_rasl_output_flag;
 
     s->is_nalff        = s0->is_nalff;
     s->nal_length_size = s0->nal_length_size;
@@ -3239,6 +3242,7 @@ static av_cold int hevc_decode_init(AVCodecContext *avctx)
 
     s->enable_parallel_tiles = 0;
     s->picture_struct = 0;
+    s->eos = 1;
 
     if(avctx->active_thread_type & FF_THREAD_SLICE)
         s->threads_number = avctx->thread_count;
@@ -3280,6 +3284,7 @@ static void hevc_decode_flush(AVCodecContext *avctx)
     HEVCContext *s = avctx->priv_data;
     ff_hevc_flush_dpb(s);
     s->max_ra = INT_MAX;
+    s->eos = 1;
 }
 
 #define OFFSET(x) offsetof(HEVCContext, x)

--- a/libavcodec/hevc.h
+++ b/libavcodec/hevc.h
@@ -866,6 +866,7 @@ typedef struct HEVCContext {
     int bs_height;
 
     int is_decoded;
+    int no_rasl_output_flag;
 
     HEVCPredContext hpc;
     HEVCDSPContext hevcdsp;

--- a/libavcodec/hevc_parser.c
+++ b/libavcodec/hevc_parser.c
@@ -410,19 +410,30 @@ static int hevc_split(AVCodecContext *avctx, const uint8_t *buf, int buf_size)
 {
     const uint8_t *ptr = buf, *end = buf + buf_size;
     uint32_t state = -1;
-    int has_ps = 0, nut;
+    int has_vps = 0;
+    int has_sps = 0;
+    int has_pps = 0;
+    int nut;
 
     while (ptr < end) {
         ptr = avpriv_find_start_code(ptr, end, &state);
         if ((state >> 8) != START_CODE)
             break;
         nut = (state >> 1) & 0x3F;
-        if (nut >= NAL_VPS && nut <= NAL_PPS)
-            has_ps = 1;
-        else if (has_ps)
-            return ptr - 4 - buf;
-        else // no parameter set at the beginning of the stream
-            return 0;
+        if (nut == NAL_VPS)
+            has_vps = 1;
+        else if (nut == NAL_SPS)
+            has_sps = 1;
+        else if (nut == NAL_PPS)
+            has_pps = 1;
+        else if ((nut != NAL_SEI_PREFIX || has_pps) &&
+                  nut != NAL_AUD) {
+            if (has_vps && has_sps) {
+                while (ptr - 4 > buf && ptr[-5] == 0)
+                    ptr--;
+                return ptr - 4 - buf;
+            }
+        }
     }
     return 0;
 }

--- a/libavcodec/hevc_refs.c
+++ b/libavcodec/hevc_refs.c
@@ -174,7 +174,7 @@ int ff_hevc_output_frame(HEVCContext *s, AVFrame *out, int flush)
         int min_poc   = INT_MAX;
         int i, min_idx, ret;
 
-        if (s->sh.no_output_of_prior_pics_flag == 1) {
+        if (s->sh.no_output_of_prior_pics_flag == 1 && s->no_rasl_output_flag == 1) {
             for (i = 0; i < FF_ARRAY_ELEMS(s->DPB); i++) {
                 HEVCFrame *frame = &s->DPB[i];
                 if (!(frame->flags & HEVC_FRAME_FLAG_BUMPING) && frame->poc != s->poc &&

--- a/libavformat/mov.c
+++ b/libavformat/mov.c
@@ -4511,8 +4511,8 @@ static AVIndexEntry *mov_find_next_sample(AVFormatContext *s, AVStream **st)
             if (!sample || (!s->pb->seekable && current_sample->pos < sample->pos) ||
                 (s->pb->seekable &&
                  ((msc->pb != s->pb && dts < best_dts) || (msc->pb == s->pb &&
-                 ((FFABS(best_dts - dts) <= AV_TIME_BASE && current_sample->pos < sample->pos) ||
-                  (FFABS(best_dts - dts) > AV_TIME_BASE && dts < best_dts)))))) {
+                 ((FFABS(best_dts - dts) <= 4*AV_TIME_BASE && current_sample->pos < sample->pos) ||
+                  (FFABS(best_dts - dts) > 4*AV_TIME_BASE && dts < best_dts)))))) {
                 sample = current_sample;
                 best_dts = dts;
                 *st = avst;

--- a/libavformat/mpegts.c
+++ b/libavformat/mpegts.c
@@ -1028,7 +1028,7 @@ static int mpegts_push_data(MpegTSFilter *filter,
                         goto skip;
 
                     /* stream not present in PMT */
-                    if (!pes->st) {
+                    if (ts->auto_guess && !pes->st) {
                         if (ts->skip_changes)
                             goto skip;
 

--- a/libavformat/mpegts.c
+++ b/libavformat/mpegts.c
@@ -91,6 +91,7 @@ struct MpegTSFilter {
     int es_id;
     int last_cc; /* last cc code (-1 if first packet) */
     int64_t last_pcr;
+    int last_version; /* last version of data on this pid */
     enum MpegTSFilterType type;
     union {
         MpegTSPESFilter pes_filter;
@@ -459,6 +460,7 @@ static MpegTSFilter *mpegts_open_filter(MpegTSContext *ts, unsigned int pid,
     filter->es_id   = -1;
     filter->last_cc = -1;
     filter->last_pcr= -1;
+    filter->last_version = -1;
 
     return filter;
 }
@@ -2021,6 +2023,10 @@ static void pat_cb(MpegTSFilter *filter, const uint8_t *section, int section_len
         return;
     if (!h->current)
         return;
+    if (h->version == filter->last_version)
+        return;
+    filter->last_version = h->version;
+    av_dlog(ts->stream, "version=%d\n", filter->last_version);
 
     if (skip_identical(h, tssf))
         return;

--- a/libavformat/mpegts.c
+++ b/libavformat/mpegts.c
@@ -866,6 +866,10 @@ static void reset_pes_packet_state(PESContext *pes)
 
 static void new_pes_packet(PESContext *pes, AVPacket *pkt)
 {
+    if(pkt->data) {
+      av_log(pes->stream, AV_LOG_ERROR, "ignoring previously allocated packet on stream %d\n", pkt->stream_index);
+      av_free_packet(pkt);
+    }
     av_init_packet(pkt);
 
     pkt->buf  = pes->buffer;
@@ -2707,6 +2711,8 @@ static int mpegts_read_packet(AVFormatContext *s, AVPacket *pkt)
 
     pkt->size = -1;
     ts->pkt = pkt;
+    ts->pkt->data = NULL;
+
     ret = handle_packets(ts, 0);
     if (ret < 0) {
         av_free_packet(ts->pkt);

--- a/libavformat/mpegts.c
+++ b/libavformat/mpegts.c
@@ -2516,6 +2516,44 @@ static void seek_back(AVFormatContext *s, AVIOContext *pb, int64_t pos) {
         av_log(s, pb->seekable ? AV_LOG_ERROR : AV_LOG_INFO, "Unable to seek back to the start\n");
 }
 
+static int parse_timestamp(int64_t *ts, const uint8_t *buf)
+{
+    int afc, flags;
+    const uint8_t *p;
+
+    if(!(buf[1] & 0x40)) /* must be a start packet */
+        return -1;
+
+    afc = (buf[3] >> 4) & 3;
+    p = buf + 4;
+    if (afc == 0 || afc == 2) /* invalid or only adaption field */
+        return -1;
+    if (afc == 3)
+        p += p[0] + 1;
+    if (p >= buf + TS_PACKET_SIZE)
+        return -1;
+
+    if (p[0] != 0x00 || p[1] != 0x00 || p[2] != 0x01)  /* packet_start_code_prefix */
+        return -1;
+
+    flags = p[3] | 0x100; /* stream type */
+    if (!((flags >= 0x1c0 && flags <= 0x1df) ||
+          (flags >= 0x1e0 && flags <= 0x1ef) ||
+          (flags == 0x1bd) || (flags == 0x1fd)))
+        return -1;
+
+    flags = p[7];
+    if ((flags & 0xc0) == 0x80) {
+        *ts = ff_parse_pes_pts(p+9);
+        return 0;
+    } else if ((flags & 0xc0) == 0xc0) {
+        *ts = ff_parse_pes_pts(p+9+5);
+        return 0;
+    }
+    return -1;
+}
+
+
 static int mpegts_read_header(AVFormatContext *s)
 {
     MpegTSContext *ts = s->priv_data;
@@ -2716,6 +2754,7 @@ static av_unused int64_t mpegts_get_pcr(AVFormatContext *s, int stream_index,
     uint8_t buf[TS_PACKET_SIZE];
     int pcr_l, pcr_pid =
         ((PESContext *)s->streams[stream_index]->priv_data)->pcr_pid;
+    int pid = ((PESContext*)s->streams[stream_index]->priv_data)->pid;
     int pos47 = ts->pos47_full % ts->raw_packet_size;
     pos =
         ((*ppos + ts->raw_packet_size - 1 - pos47) / ts->raw_packet_size) *
@@ -2734,6 +2773,11 @@ static av_unused int64_t mpegts_get_pcr(AVFormatContext *s, int stream_index,
         }
         if ((pcr_pid < 0 || (AV_RB16(buf + 1) & 0x1fff) == pcr_pid) &&
             parse_pcr(&timestamp, &pcr_l, buf) == 0) {
+            *ppos = pos;
+            return timestamp;
+        }
+        if ((pid < 0 || (AV_RB16(buf + 1) & 0x1fff) == pid) &&
+            parse_timestamp(&timestamp, buf) == 0) {
             *ppos = pos;
             return timestamp;
         }
@@ -2836,7 +2880,7 @@ AVInputFormat ff_mpegts_demuxer = {
     .read_header    = mpegts_read_header,
     .read_packet    = mpegts_read_packet,
     .read_close     = mpegts_read_close,
-    .read_timestamp = mpegts_get_dts,
+    .read_timestamp = mpegts_get_pcr,
     .flags          = AVFMT_SHOW_IDS | AVFMT_TS_DISCONT,
     .priv_class     = &mpegts_class,
 };
@@ -2848,7 +2892,7 @@ AVInputFormat ff_mpegtsraw_demuxer = {
     .read_header    = mpegts_read_header,
     .read_packet    = mpegts_raw_read_packet,
     .read_close     = mpegts_read_close,
-    .read_timestamp = mpegts_get_dts,
+    .read_timestamp = mpegts_get_pcr,
     .flags          = AVFMT_SHOW_IDS | AVFMT_TS_DISCONT,
     .priv_class     = &mpegtsraw_class,
 };

--- a/libavformat/mpegts.c
+++ b/libavformat/mpegts.c
@@ -585,6 +585,7 @@ typedef struct SectionHeader {
     uint8_t tid;
     uint16_t id;
     uint8_t version;
+    uint8_t current;
     uint8_t sec_num;
     uint8_t last_sec_num;
 } SectionHeader;
@@ -667,6 +668,7 @@ static int parse_section_header(SectionHeader *h,
     val = get8(pp, p_end);
     if (val < 0)
         return val;
+    h->current = val & 0x1;
     h->version = (val >> 1) & 0x1f;
     val = get8(pp, p_end);
     if (val < 0)
@@ -2016,6 +2018,8 @@ static void pat_cb(MpegTSFilter *filter, const uint8_t *section, int section_len
     if (h->tid != PAT_TID)
         return;
     if (ts->skip_changes)
+        return;
+    if (!h->current)
         return;
 
     if (skip_identical(h, tssf))

--- a/libavformat/mpegts.c
+++ b/libavformat/mpegts.c
@@ -755,6 +755,8 @@ static const StreamType DESC_types[] = {
     { 0x7b, AVMEDIA_TYPE_AUDIO,    AV_CODEC_ID_DTS          },
     { 0x56, AVMEDIA_TYPE_SUBTITLE, AV_CODEC_ID_DVB_TELETEXT },
     { 0x59, AVMEDIA_TYPE_SUBTITLE, AV_CODEC_ID_DVB_SUBTITLE }, /* subtitling descriptor */
+    { 0x45, AVMEDIA_TYPE_DATA,         AV_CODEC_ID_VBI_DATA }, /* VBI Data descriptor */
+    { 0x46, AVMEDIA_TYPE_DATA,     AV_CODEC_ID_VBI_TELETEXT }, /* VBI Teletext descriptor */
     { 0 },
 };
 

--- a/libavformat/utils.c
+++ b/libavformat/utils.c
@@ -1329,6 +1329,8 @@ static int read_frame_internal(AVFormatContext *s, AVPacket *pkt)
         if (ret < 0) {
             if (ret == AVERROR(EAGAIN))
                 return ret;
+            if (ret == AVERROR(EIO))
+                return ret;
             /* flush the parsers */
             for (i = 0; i < s->nb_streams; i++) {
                 st = s->streams[i];

--- a/libavformat/utils.c
+++ b/libavformat/utils.c
@@ -2455,6 +2455,41 @@ static void estimate_timings_from_bit_rate(AVFormatContext *ic)
 #define DURATION_MAX_READ_SIZE 250000LL
 #define DURATION_MAX_RETRY 4
 
+static void av_estimate_timings_from_pts2(AVFormatContext *ic, int64_t old_offset)
+{
+    AVStream *st;
+    int i, step= 1024;
+    int64_t ts, pos;
+
+    for(i=0;i<ic->nb_streams;i++) {
+        st = ic->streams[i];
+
+        pos = 0;
+        ts = ic->iformat->read_timestamp(ic, i, &pos, DURATION_MAX_READ_SIZE);
+        if (ts == AV_NOPTS_VALUE)
+            continue;
+        if (st->start_time > ts || st->start_time == AV_NOPTS_VALUE)
+            st->start_time = ts;
+
+        pos = avio_size(ic->pb) - 1;
+        do {
+            pos -= step;
+            ts = ic->iformat->read_timestamp(ic, i, &pos, pos + step);
+            step += step;
+        } while (ts == AV_NOPTS_VALUE && pos >= step && step < DURATION_MAX_READ_SIZE);
+
+        if (ts == AV_NOPTS_VALUE)
+            continue;
+
+        if (st->duration < ts - st->start_time || st->duration == AV_NOPTS_VALUE)
+            st->duration = ts - st->start_time;
+    }
+
+    fill_all_stream_timings(ic);
+
+    avio_seek(ic->pb, old_offset, SEEK_SET);
+}
+
 /* only usable for MPEG-PS streams */
 static void estimate_timings_from_pts(AVFormatContext *ic, int64_t old_offset)
 {
@@ -2605,6 +2640,10 @@ static void estimate_timings(AVFormatContext *ic, int64_t old_offset)
          * the components */
         fill_all_stream_timings(ic);
         ic->duration_estimation_method = AVFMT_DURATION_FROM_STREAM;
+    } else if (ic->iformat->read_timestamp && 
+        file_size && ic->pb->seekable) {
+        /* get accurate estimate from the PTSes */
+        av_estimate_timings_from_pts2(ic, old_offset);
     } else {
         /* less precise: use bitrate info */
         estimate_timings_from_bit_rate(ic);

--- a/version.sh
+++ b/version.sh
@@ -2,30 +2,32 @@
 
 # Usage: version.sh <ffmpeg-root-dir> <output-version.h> <extra-version>
 
+if [ -d $1/.git ]; then  # only check for a git rev, if the src tree is in a git repo
 # check for git short hash
-if ! test "$revision"; then
+  if ! test "$revision"; then
     if (cd "$1" && grep git RELEASE 2> /dev/null >/dev/null) ; then
         revision=$(cd "$1" && git describe --tags --match N 2> /dev/null)
     else
         revision=$(cd "$1" && git describe --tags --always 2> /dev/null)
     fi
-fi
+  fi
 
-# Shallow Git clones (--depth) do not have the N tag:
-# use 'git-YYYY-MM-DD-hhhhhhh'.
-test "$revision" || revision=$(cd "$1" &&
-  git log -1 --pretty=format:"git-%cd-%h" --date=short 2> /dev/null)
+  # Shallow Git clones (--depth) do not have the N tag:
+  # use 'git-YYYY-MM-DD-hhhhhhh'.
+  test "$revision" || revision=$(cd "$1" &&
+    git log -1 --pretty=format:"git-%cd-%h" --date=short 2> /dev/null)
 
-# Snapshots from gitweb are in a directory called ffmpeg-hhhhhhh or
-# ffmpeg-HEAD-hhhhhhh.
-if [ -z "$revision" ]; then
-  srcdir=$(cd "$1" && pwd)
-  case "$srcdir" in
-    */ffmpeg-[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f])
-      git_hash="${srcdir##*-}";;
-    */ffmpeg-HEAD-[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f])
-      git_hash="${srcdir##*-}";;
-  esac
+  # Snapshots from gitweb are in a directory called ffmpeg-hhhhhhh or
+  # ffmpeg-HEAD-hhhhhhh.
+  if [ -z "$revision" ]; then
+    srcdir=$(cd "$1" && pwd)
+    case "$srcdir" in
+      */ffmpeg-[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f])
+        git_hash="${srcdir##*-}";;
+      */ffmpeg-HEAD-[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f])
+        git_hash="${srcdir##*-}";;
+    esac
+  fi
 fi
 
 # no revision number found


### PR DESCRIPTION
This is a one button solution to get your kodi's ffmpeg to a fixed hevc one.
